### PR TITLE
Adjustments to packetfilter PrependUnique/InsertUnique

### DIFF
--- a/pkg/packetfilter/adapter.go
+++ b/pkg/packetfilter/adapter.go
@@ -123,12 +123,3 @@ func (a *Adapter) UpdateChainRules(table TableType, chain string, rules []*Rule)
 
 	return nil
 }
-
-func (a *Adapter) InsertUnique(table TableType, chain string, position int, rule *Rule) error {
-	existingRules, err := a.List(table, chain)
-	if err != nil {
-		return err
-	}
-
-	return a.ensureRuleAtPosition(table, chain, existingRules, position, rule)
-}

--- a/pkg/packetfilter/adapter_test.go
+++ b/pkg/packetfilter/adapter_test.go
@@ -1,0 +1,145 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packetfilter_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/packetfilter"
+	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
+)
+
+const chain = "test-chain"
+
+var _ = Describe("Adapter", func() {
+	var (
+		pFilter *fakePF.PacketFilter
+		adapter packetfilter.Interface
+	)
+
+	BeforeEach(func() {
+		pFilter = fakePF.New()
+
+		var err error
+
+		adapter, err = packetfilter.New()
+		Expect(err).To(Succeed())
+
+		Expect(pFilter.CreateChainIfNotExists(packetfilter.TableTypeNAT, &packetfilter.Chain{
+			Name: chain,
+		})).To(Succeed())
+	})
+
+	Context("PrependUnique", func() {
+		otherRule := &packetfilter.Rule{
+			Action:      packetfilter.RuleActionJump,
+			TargetChain: "other-chain",
+		}
+
+		rule1 := &packetfilter.Rule{
+			Action:       packetfilter.RuleActionAccept,
+			Proto:        packetfilter.RuleProtoUDP,
+			OutInterface: "out-iface",
+			InInterface:  "in-iface",
+			DPort:        "1",
+		}
+
+		rule2 := &packetfilter.Rule{
+			Action:    packetfilter.RuleActionMark,
+			Proto:     packetfilter.RuleProtoTCP,
+			MarkValue: "mark",
+			SrcCIDR:   "171.254.1.0/24",
+			DestCIDR:  "172.254.1.0/24",
+		}
+
+		rule3 := &packetfilter.Rule{
+			Action:      packetfilter.RuleActionMss,
+			Proto:       packetfilter.RuleProtoAll,
+			ClampType:   packetfilter.ToPMTU,
+			SrcSetName:  "src-set",
+			DestSetName: "dest-set",
+			MssValue:    "123",
+		}
+
+		rule4 := &packetfilter.Rule{
+			Action:      packetfilter.RuleActionJump,
+			Proto:       packetfilter.RuleProtoICMP,
+			TargetChain: "target-chain",
+		}
+
+		rule5 := &packetfilter.Rule{
+			Action:   packetfilter.RuleActionSNAT,
+			Proto:    packetfilter.RuleProtoAll,
+			SnatCIDR: "172.254.1.0/24",
+		}
+
+		rule6 := &packetfilter.Rule{
+			Action:   packetfilter.RuleActionDNAT,
+			Proto:    packetfilter.RuleProtoICMP,
+			DnatCIDR: "173.254.1.0/24",
+		}
+
+		When("the rules don't exist", func() {
+			It("should prepend them", func() {
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, otherRule)).To(Succeed())
+
+				Expect(adapter.PrependUnique(packetfilter.TableTypeNAT, chain, rule1, rule2, rule3)).To(Succeed())
+				assertRules(pFilter, rule1, rule2, rule3, otherRule)
+			})
+		})
+
+		When("the rules already exist in the proper position", func() {
+			It("should not prepend them", func() {
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule1)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule2)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule3)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, otherRule)).To(Succeed())
+
+				Expect(adapter.PrependUnique(packetfilter.TableTypeNAT, chain, rule1, rule2, rule3)).To(Succeed())
+				assertRules(pFilter, rule1, rule2, rule3, otherRule)
+			})
+		})
+
+		When("rules already exist but not in the proper position", func() {
+			It("should remove the misplaced rules and prepend them", func() {
+				otherRule2 := &packetfilter.Rule{
+					Action: packetfilter.RuleActionDNAT,
+					Proto:  packetfilter.RuleProtoAll,
+				}
+
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule4)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, otherRule)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule1)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule2)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, otherRule2)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule3)).To(Succeed())
+				Expect(adapter.Append(packetfilter.TableTypeNAT, chain, rule1)).To(Succeed())
+
+				Expect(adapter.PrependUnique(packetfilter.TableTypeNAT, chain, rule1, rule2, rule3, rule4, rule5, rule6)).To(Succeed())
+				assertRules(pFilter, rule1, rule2, rule3, rule4, rule5, rule6, otherRule, otherRule2)
+			})
+		})
+	})
+})
+
+func assertRules(pFilter packetfilter.Driver, expected ...*packetfilter.Rule) {
+	actual, err := pFilter.List(packetfilter.TableTypeNAT, chain)
+	Expect(err).To(Succeed())
+	Expect(actual).To(Equal(expected))
+}

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -303,7 +303,6 @@ type Driver interface {
 
 type Interface interface {
 	Driver
-	InsertUnique(table TableType, chain string, position int, ruleSpec *Rule) error
 	PrependUnique(table TableType, chain string, rules ...*Rule) error
 	UpdateChainRules(table TableType, chain string, rules []*Rule) error
 }

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -304,7 +304,7 @@ type Driver interface {
 type Interface interface {
 	Driver
 	InsertUnique(table TableType, chain string, position int, ruleSpec *Rule) error
-	PrependUnique(table TableType, chain string, ruleSpec *Rule) error
+	PrependUnique(table TableType, chain string, rules ...*Rule) error
 	UpdateChainRules(table TableType, chain string, rules []*Rule) error
 }
 

--- a/pkg/packetfilter/packetfilter_suite_test.go
+++ b/pkg/packetfilter/packetfilter_suite_test.go
@@ -1,0 +1,41 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packetfilter_test
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+var _ = BeforeSuite(func() {
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	_ = flags.Parse([]string{"-v=4"})
+
+	kzerolog.InitK8sLogging()
+})
+
+func TestPacketFilter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PacketFilter Suite")
+}


### PR DESCRIPTION
`InsertUnique` intends to ensure the rule is at the desired position in the chain and will delete any misplaced occurrences and re-insert at the desired position. The problem with this is that if a misplaced occurrence is before the desired position then deleting the misplaced occurrence invalidates the desired position. Also if the desired position is now far enough beyond the end of the chain then `Insert` will fail. It really only works when prepending to the front of the chain. In fact, looking back at the history,  this code was originally used for prepending and was later generalized in `InsertUnique`.

The only usage of `InsertUnique` is in [createGlobalnetChains](https://github.com/submariner-io/submariner/blob/3248d61fd6e20a6cb1d877ce75e30ba2a226faa6/pkg/globalnet/controllers/gateway_monitor.go#L559). It prepends the first rule to ensure it's at the front of the chain then calls `InsertUnique` for the subsequent rules with successive positions, ie 2, 3, 4 etc. So the code is really prepending several rules in order at the front of the chain. Rather than using `PrependUnique` followed by `InsertUnique`, we can modify `PrependUnique` to take a list of rules to prepend. This makes it explicit in the API. We can then remove the `InsertUnique` method from the API to avoid exposing the bug if it's not used properly.

Unit tests were also added for `PrependUnique` and the other `Adapter` methods.

See individual commits for details.