### PR TITLE
Add nftables+dual-stack E2E test to CI matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,6 +60,7 @@ jobs:
           - extra-toggles: dual-stack, globalnet
           - extra-toggles: ipv6-stack
           - extra-toggles: nftables
+          - extra-toggles: nftables, dual-stack
           - extra-toggles: nftables, ovn
           - extra-toggles: nftables, globalnet
           - extra-toggles: nftables, globalnet, ovn


### PR DESCRIPTION
This test combination was missing from the CI matrix, which prevented detection of nftables protocol handling bugs in dual-stack environments with kube-proxy mode.

The existing nftables+dual-stack+ovn test doesn't exercise the same code paths because OVN doesn't use protocol-based packet filter rules.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
